### PR TITLE
Moving "Loading Packages with Binaries from a Network Location" to the Dynamo Primer

### DIFF
--- a/6_custom_nodes_and_packages/6-2_packages/1-introduction.md
+++ b/6_custom_nodes_and_packages/6-2_packages/1-introduction.md
@@ -91,6 +91,20 @@ If you would like to see where your package files are kept, in the top navigatio
 
 By default, packages are installed in a location similar to this folder path: _C:/Users/\[username]/AppData/Roaming/Dynamo/\[Dynamo Version]_.
 
+### Loading Packages with Binaries from a Network Location
+
+#### Scenario
+
+An organization might want to standardize the packages installed by different workstations and users. A way to do this, could be to install these packages from Package Manager selecting a network folder as the install location, and get workstations to add that path to `Manage Node and Package Paths`.
+
+#### Problem
+
+While the scenario works properly for packages that contain only custom nodes, it might not work for packages containing binaries, like zero-touch nodes. This issue is caused by [security measures](https://stackoverflow.com/questions/5328274/load-assembly-from-network-location) the .NET framework places over loading assemblies when they come from a network location. Unfortunately, using the `loadFromRemoteSources` configuration element, as suggested in the linked thread, is not a possible solution for Dynamo, because it is distributed as a component rather than an application.
+
+#### Workaround
+
+One possible workaround is to use a mapped network drive pointing to the network location, and have workstations reference that path instead. The steps to create a mapped network drive are described [here](https://support.microsoft.com/en-us/help/4026635/windows-10-map-a-network-drive).
+
 ### Going Further with Packages
 
 The Dynamo community is constantly growing and evolving. By exploring the Dynamo Package Manager from time to time, you'll find some exciting new developments. In the following sections, we'll take a more in-depth look at packages, from the end-user perspective to authorship of your own Dynamo Package.


### PR DESCRIPTION
Purpose
Moving the "[Loading Packages from Binaries from a Network Location](https://github.com/DynamoDS/Dynamo/wiki/Loading-Packages-with-Binaries-from-a-Network-Location)" from the Dynamo Wiki to the Dynamo Primer.

Key additions:
A guide on how to load packages from binaries from a Network Location.

Declarations
Check these if you believe they are true
- [ ]  The codebase is in a better state after this PR
- [ ]  Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ]  The level of testing this PR includes is appropriate
- [ ]  User facing strings, if any, are extracted into *.resx files
- [ ]  All tests pass using the self-service CI.
- [ ]  Snapshot of UI changes, if any.
- [ ]  Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ]  This PR modifies some build requirements and the readme is updated
- [ ]  This PR contains no files larger than 50 MB


Release Notes
Adding a section to the primer for Loading Packages from Binaries from a Network Location.

Reviewers
@dnenov
@achintyabhat
@QilongTang

Informed
@Amoursol