### PR TITLE
Moving Dynamo Keyboard Shortcuts from the Dynamo Wiki to the Dynamo Primer

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -130,3 +130,4 @@
   * [Example Files](a\_appendix/a-4\_example-files.md)
   * [Host Integration Map](a\_appendix/host-integration-map.md)
   * [Download PDF](a\_appendix/a-5\_download-pdf.md)
+  * [Dynamo Keyboard Shortcuts](a\_appendix/a-6\_dynamo-keyboard-shortcuts.md)

--- a/a_appendix/a-6_dynamo-keyboard-shortcuts.md
+++ b/a_appendix/a-6_dynamo-keyboard-shortcuts.md
@@ -29,7 +29,7 @@
 
 `CTRL + T` Open an existing template.
 
-`CTRL + P` Toggle ‘Pan’ mode.
+`CTRL + P` Toggle ‘Pan mode.
 
 `CTRL + S` Save the active file (dyn or dyf).
 
@@ -45,7 +45,7 @@
 
 `CTRL + 0` Zoom extents if nothing selected, Zoom to origin if already at extents, Zoom to selection if node(s), note(s) or group(s) are selected.
 
-`­­­­CTRL + - (not number pad)` Zoom out.
+`­­CTRL + - (not number pad)` Zoom out.
 
 `CTRL + =` Zoom in.
 
@@ -56,7 +56,7 @@
 
 ### Workspace view single key shortcuts:
 
-`Esc (hold)` Toggle to geometry preview – will revert to workspace view once released.
+`Esc (hold)` Toggle to geometry preview - will revert to workspace view once released.
 
 `Tab` Add nodes connected to current selection to selection (select nodes at end of highlighted wires).
 
@@ -108,7 +108,7 @@
 
 `CTRL + C` Copy selected geometry.
 
-`CTRL + D` Creates new custom node from the node which creates the selected geometry(s). Exactly what is included in the custom node can expand beyond the specific nodes – best to be careful when using this with a selection from the geometry preview windows.
+`CTRL + D` Creates new custom node from the node which creates the selected geometry(s). Exactly what is included in the custom node can expand beyond the specific nodes - best to be careful when using this with a selection from the geometry preview windows.
 
 `CTRL + E` Sets zoom to the default distance and re-centers camera.
 
@@ -140,7 +140,7 @@
 
 `CTRL + 0` Zoom extents if nothing selected. Zoom to selected geometry if any is selected.
 
-`­­­­CTRL + - (not number pad)` Zoom out from pivot point.
+`CTRL + - (not number pad)` Zoom out from pivot point.
 
 `CTRL + =` Zoom in towards pivot point.
 

--- a/a_appendix/a-6_dynamo-keyboard-shortcuts.md
+++ b/a_appendix/a-6_dynamo-keyboard-shortcuts.md
@@ -1,0 +1,152 @@
+# Dynamo Keyboard Shortcuts
+
+
+### Workspace view based CTRL key combinations (hold ctrl key and press the additional keys listed)
+
+`CTRL + A` Select all nodes in workspace.
+
+`CTRL + B` Switch between geometry preview and workspace.
+
+`CTRL + C` Copy the selected node(s), note(s), group(s).
+
+`CTRL + D` Creates new custom node from the selected node(s), note(s), group(s).
+
+`CTRL + G` Groups the current selection (if possible).
+
+`CTRL + I` Enables Isolation mode, which fades geometry associated to nodes which are not selected.
+
+`CTRL + K` Unpin all node previews.
+
+`CTRL + SHIFT + I` Insert graph.
+
+`CTRL + L` Clean up node layout, which adjusts node locations to produce a more readable graph.
+
+`CTRL + N` Creates a new graph.
+
+`CTRL + SHIFT + N` Creates a new custom node.
+
+`CTRL + O` Open an existing graph.
+
+`CTRL + T` Open an existing template.
+
+`CTRL + P` Toggle ‘Pan’ mode.
+
+`CTRL + S` Save the active file (dyn or dyf).
+
+`CTRL + SHIFT + S` Save the active file (dyn or dyf) as a new file.
+
+`CTRL + V` Paste nodes from clipboard.
+
+`CTRL + W` Create note.
+
+`CTRL + Y` Redo a previously undone action.
+
+`CTRL + Z` Undo an action.
+
+`CTRL + 0` Zoom extents if nothing selected, Zoom to origin if already at extents, Zoom to selection if node(s), note(s) or group(s) are selected.
+
+`­­­­CTRL + - (not number pad)` Zoom out.
+
+`CTRL + =` Zoom in.
+
+`CTRL + SHIFT + UPARROW` Toggle console.
+
+`ALT + Left Click` Remove Node from Group.
+
+
+### Workspace view single key shortcuts:
+
+`Esc (hold)` Toggle to geometry preview – will revert to workspace view once released.
+
+`Tab` Add nodes connected to current selection to selection (select nodes at end of highlighted wires).
+
+`F5` Run the graph (when in manual execution mode).
+
+`Delete` Removes the selected node(s) from the workspace.
+
+`F1` Displays the node help documentation for the last selected node in the workspace.
+ 
+
+### Workspace Mouse Interaction:
+
+`Left click` Select node.
+
+`Double left click` Create new code block.
+
+`Right click node body` Node context menu.
+
+`Right click node input` Port context menu. 
+
+`Right click group` Group context window.
+
+`Right click background and type` Quick access library search.
+
+`Right click background` Workspace context window.
+
+`Right click note` Note context window.
+
+`Middle Mouse click and drag` Pan workspace.
+
+`Middle Mouse Scroll` Zoom in/out.
+
+`Shift + Left Mouse + drag on connected out port` Grab all wires and remove from node. Release on other out port to reattach. Release on background to remove wires from graph.
+
+`CTRL + Left Mouse on connected input` Duplicate connector mode. Connect to as many ports as desired. Release ctrl and click to cancel additional connector creation.
+
+`Shift + Left Mouse on node body` Add to selection.
+
+`Left Mouse drag to create a box from left to right` Select node(s), note(s), groups which are completely contained inside the box. Note solid box lines.
+
+`Left Mouse drag to create a box from right to left` Select node(s), note(s), group(s) which are inside or partially inside the box. Note dashed box lines. 
+
+
+### Geometry Preview CTRL key combinations (hold ctrl key and press the additional keys listed):
+
+`CTRL + A` Select all nodes in the workspace and allow direct geometry manipulation as applicable to the elements in the display.
+
+`CTRL + B` Toggle to workspace view.
+
+`CTRL + C` Copy selected geometry.
+
+`CTRL + D` Creates new custom node from the node which creates the selected geometry(s). Exactly what is included in the custom node can expand beyond the specific nodes – best to be careful when using this with a selection from the geometry preview windows.
+
+`CTRL + E` Sets zoom to the default distance and re-centers camera.
+
+`CTRL + G` Group the nodes which create the selected geometry in the workspace.
+
+`CTRL + I` Enables Isolation mode, which fades geometry associated to nodes which are not selected.
+
+`CTRL + L` Clean up node layout, which adjusts node locations to produce a more readable graph.
+
+`CTRL + N` Creates a new graph.
+
+`CTRL + SHIFT + N` Creates a new custom node.
+
+`CTRL + O` Open an existing graph.
+
+`CTRL + S` Save the active file (dyn or dyf).
+
+`CTRL + SHIFT + S` Save the active file (dyn or dyf) as a new file.
+
+`CTRL + V` Paste nodes from clipboard.
+
+`CTRL + W` Create note in the workspace. These can be hard to find, so careful with them.
+
+`CTRL + X` Cut selected node(s), note(s), group(s).
+
+`CTRL + Y` Redo a previously undone action.
+
+`CTRL + Z` Undo an action.
+
+`CTRL + 0` Zoom extents if nothing selected. Zoom to selected geometry if any is selected.
+
+`­­­­CTRL + - (not number pad)` Zoom out from pivot point.
+
+`CTRL + =` Zoom in towards pivot point.
+
+`CTRL + SHIFT + UPARROW` Toggle console.
+
+
+### Geometry Preview single key shortcuts:
+
+`Delete` Removes the selected node(s) from the workspace.

--- a/a_appendix/a-6_dynamo-keyboard-shortcuts.md
+++ b/a_appendix/a-6_dynamo-keyboard-shortcuts.md
@@ -29,7 +29,7 @@
 
 `CTRL + T` Open an existing template.
 
-`CTRL + P` Toggle ‘Pan mode.
+`CTRL + P` Toggle Pan mode.
 
 `CTRL + S` Save the active file (dyn or dyf).
 
@@ -45,7 +45,7 @@
 
 `CTRL + 0` Zoom extents if nothing selected, Zoom to origin if already at extents, Zoom to selection if node(s), note(s) or group(s) are selected.
 
-`­­CTRL + - (not number pad)` Zoom out.
+`CTRL + - (not number pad)` Zoom out.
 
 `CTRL + =` Zoom in.
 


### PR DESCRIPTION
### Purpose
Moving [Dynamo Keyboard Shortcuts](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Keyboard-Shortcuts) from the Dynamo Wiki to the Dynamo Primer

### Key additions:
A guide on the Keyboard shortcuts available to use in dynamo.

### Declarations
Check these if you believe they are true
- [ ]  The codebase is in a better state after this PR
- [ ]  Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ]  The level of testing this PR includes is appropriate
- [ ]  User facing strings, if any, are extracted into *.resx files
- [ ]  All tests pass using the self-service CI.
- [ ]  Snapshot of UI changes, if any.
- [ ]  Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ]  This PR modifies some build requirements and the readme is updated
- [ ]  This PR contains no files larger than 50 MB

### Release Notes
Adding a section to the Primer detailing all of the keyboard shortcuts available to use within Dynamo.

Reviewers
@dnenov
@achintyabhat
@QilongTang

Informed
@Amoursol