### PR TITLE
Transferring the "Setting up a shared location for Packages in an Office" from dynamo Wiki to Primer

### DIFF
--- a/6_custom_nodes_and_packages/6-2_packages/1-introduction.md
+++ b/6_custom_nodes_and_packages/6-2_packages/1-introduction.md
@@ -91,6 +91,35 @@ If you would like to see where your package files are kept, in the top navigatio
 
 By default, packages are installed in a location similar to this folder path: _C:/Users/\[username]/AppData/Roaming/Dynamo/\[Dynamo Version]_.
 
+### Setting up a Shared Location for Packages in an Office
+
+For users who are asking if it is possible to deploy Dynamo (in any form) with pre-attached packages:
+The approach that will solve this issue and allow for control at a central location for all users with Dynamo installs is to add a custom package path to each installation.
+
+**Adding a network folder where the BIM manager or others could supervise the stocking of the folder with office approved packages**  
+In the UI of an individual application, go to *Dynamo -> Preferences -> Package Settings -> Node and Package file locations*.  In the dialog, press the "Add Path" button and browse to the network location for the shared package resource. 
+ 
+As an automated process, it would involve adding information to the configuration file that is installed with Dynamo:  C:\Users\Username\AppData\Roaming\Dynamo\Dynamo Revit\3.2\DynamoSettings.xml. By default, the configuration for Dynamo for Revit is:
+ 
+`<CustomPackageFolders>`  
+
+`<string>C:\Users\kronz\AppData\Roaming\Dynamo\Dynamo Revit\3.2</string>`  
+
+`</CustomPackageFolders>`
+
+Adding a custom location would look like:  
+
+`<CustomPackageFolders>`  
+
+`<string>C:\Users\kronz\AppData\Roaming\Dynamo\Dynamo Revit\3.2</string>`  
+
+`<string>N:\OfficeFiles\Dynamo\Packages_Limited</string>`  
+
+`</CustomPackageFolders>`
+
+
+The central management for this folder can also be controlled by simply making the folder read only.
+
 ### Loading Packages with Binaries from a Network Location
 
 #### Scenario

--- a/6_custom_nodes_and_packages/6-2_packages/1-introduction.md
+++ b/6_custom_nodes_and_packages/6-2_packages/1-introduction.md
@@ -99,11 +99,11 @@ The approach that will solve this issue and allow for control at a central locat
 **Adding a network folder where the BIM manager or others could supervise the stocking of the folder with office approved packages**  
 In the UI of an individual application, go to *Dynamo -> Preferences -> Package Settings -> Node and Package file locations*.  In the dialog, press the "Add Path" button and browse to the network location for the shared package resource. 
  
-As an automated process, it would involve adding information to the configuration file that is installed with Dynamo:  C:\Users\Username\AppData\Roaming\Dynamo\Dynamo Revit\3.2\DynamoSettings.xml. By default, the configuration for Dynamo for Revit is:
+As an automated process, it would involve adding information to the configuration file that is installed with Dynamo:  _C:\Users/\[Username]\AppData\Roaming\Dynamo\Dynamo Revit/\[Dynamo Version]\DynamoSettings.xml_. By default, the configuration for Dynamo for Revit is:
  
 `<CustomPackageFolders>`  
 
-`<string>C:\Users\kronz\AppData\Roaming\Dynamo\Dynamo Revit\3.2</string>`  
+`<string>C:\Users\[Username]\AppData\Roaming\Dynamo\Dynamo Revit\[Dynamo Version]</string>`  
 
 `</CustomPackageFolders>`
 
@@ -111,7 +111,7 @@ Adding a custom location would look like:
 
 `<CustomPackageFolders>`  
 
-`<string>C:\Users\kronz\AppData\Roaming\Dynamo\Dynamo Revit\3.2</string>`  
+`<string>C:\Users\[Username]\AppData\Roaming\Dynamo\Dynamo Revit\[Dynamo Version]</string>`  
 
 `<string>N:\OfficeFiles\Dynamo\Packages_Limited</string>`  
 


### PR DESCRIPTION
### Purpose
Moving the Setting up a shared location for Packages in an [Office](https://github.com/DynamoDS/Dynamo/wiki/Setting-up-a-shared-location-for-Packages-in-an-Office) from the Dynamo Wiki to the Dynamo Primer.

### Key additions:
A guide on how to set up a shared package location for multiple users in an team. 

### Declarations
Check these if you believe they are true
- [ ]  The codebase is in a better state after this PR
- [ ]  Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ]  The level of testing this PR includes is appropriate
- [ ]  User facing strings, if any, are extracted into *.resx files
- [ ]  All tests pass using the self-service CI.
- [ ]  Snapshot of UI changes, if any.
- [ ]  Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ]  This PR modifies some build requirements and the readme is updated
- [ ]  This PR contains no files larger than 50 MB


### Release Notes
Adding a guide on how to set up a shared package location for multiple users in an team. 

### Reviewers
@dnenov
@achintyabhat
@QilongTang

Informed
@Amoursol