### PR TITLE
Transferring Using COM (interop) types in dynamo packages from Wiki to Primer

### DIFF
--- a/11_developer_primer/3_developing_for_dynamo/10-using-com-(interop)-types-in-dynamo-packages.md
+++ b/11_developer_primer/3_developing_for_dynamo/10-using-com-(interop)-types-in-dynamo-packages.md
@@ -1,0 +1,47 @@
+# Using COM (interop) types in Dynamo Packages
+
+## Some general information about interop types
+What are COM types? - https://learn.microsoft.com/en-us/windows/win32/com/the-component-object-model 
+
+The standard way to use COM types in C# is to reference and ship the primary interop assemblies (Basically a big collection of APIs) with your package. 
+
+An alternative to this is to embed the PIA (Primary interop assemblies) in your managed assembly. This basically only includes the types and members that are actually used by a managed assembly. However this approach has some other issues like type equivalence.
+
+This post describes the issue pretty well: 
+* https://learn.microsoft.com/en-us/dotnet/framework/interop/type-equivalence-and-embedded-interop-types
+
+## How Dynamo manages types equivalence
+Dynamo delegates type equivalence to the .NET (dotnet) runtime. 
+An example of this would be that 2 types with the same name and namespace, coming from different assemblies will not be considered equivalent, and Dynamo will give an error when loading the conflicting assemblies. 
+As for interop types, Dynamo will check if the interop types are equivalent using the [IsEquivalentTo API](https://learn.microsoft.com/en-us/dotnet/api/system.type.isequivalentto)
+
+## How to avoid conflicts between embedded interop types
+Some packages have already been created with embedded interop types (ex CivilConnection). 
+Loading 2 packages with embedded interop assemblies that are not considered equivalent(different versions as defined [here](https://learn.microsoft.com/en-us/dotnet/framework/interop/type-equivalence-and-embedded-interop-types)) will cause a `package load error`.
+Because of this, we suggest that package authors use dynamic binding (aka late binding) for interop types (solution is also described [here](https://blogs.iis.net/samng/the-pain-of-deploying-primary-interop-assemblies)).
+
+You can follow this example:
+```
+public class Application
+    {
+        string m_sProdID = "SomeNamespace.Application";
+        public dynamic m_oApp = null; // Use dynamic so you do not need the PIA types
+
+        public Application()
+        {
+            this.GetApplication();
+        }
+
+        internal void GetApplication()
+        {
+            try
+
+            {
+                m_oApp = System.Runtime.InteropServices.Marshal.GetActiveObject(m_sProdID);
+            }
+            catch (Exception /*ex*/)
+            {}
+        }
+    }
+}
+```

--- a/6_custom_nodes_and_packages/6-2_packages/1-introduction.md
+++ b/6_custom_nodes_and_packages/6-2_packages/1-introduction.md
@@ -91,6 +91,35 @@ If you would like to see where your package files are kept, in the top navigatio
 
 By default, packages are installed in a location similar to this folder path: _C:/Users/\[username]/AppData/Roaming/Dynamo/\[Dynamo Version]_.
 
+### Setting up a Shared Location for Packages in an Office
+
+For users who are asking if it is possible to deploy Dynamo (in any form) with pre-attached packages:
+The approach that will solve this issue and allow for control at a central location for all users with Dynamo installs is to add a custom package path to each installation.
+
+**Adding a network folder where the BIM manager or others could supervise the stocking of the folder with office approved packages**  
+In the UI of an individual application, go to *Dynamo -> Preferences -> Package Settings -> Node and Package file locations*.  In the dialog, press the "Add Path" button and browse to the network location for the shared package resource. 
+ 
+As an automated process, it would involve adding information to the configuration file that is installed with Dynamo:  C:\Users\Username\AppData\Roaming\Dynamo\Dynamo Revit\3.2\DynamoSettings.xml. By default, the configuration for Dynamo for Revit is:
+ 
+`<CustomPackageFolders>`  
+
+`<string>C:\Users\kronz\AppData\Roaming\Dynamo\Dynamo Revit\3.2</string>`  
+
+`</CustomPackageFolders>`
+
+Adding a custom location would look like:  
+
+`<CustomPackageFolders>`  
+
+`<string>C:\Users\kronz\AppData\Roaming\Dynamo\Dynamo Revit\3.2</string>`  
+
+`<string>N:\OfficeFiles\Dynamo\Packages_Limited</string>`  
+
+`</CustomPackageFolders>`
+
+
+The central management for this folder can also be controlled by simply making the folder read only.
+
 ### Loading Packages with Binaries from a Network Location
 
 #### Scenario

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -114,6 +114,7 @@
     * [Executing Python Scripts in Zero-Touch Nodes (C#)](11\_developer\_primer/3\_developing\_for\_dynamo/3-executing-python-scripts-in-zero-touch-nodes-c.md)
     * [Going Further with Zero-Touch](11\_developer\_primer/3\_developing\_for\_dynamo/4-going-further-with-zero-touch.md)
     * [Advanced Dynamo Node Customisation](11\_developer\_primer/3\_developing\_for\_dynamo/8-advanced-dynamo-node-customisation.md)
+    * [Using COM (interop) types in Dynamo Packages](11\_developer\_primer/3\_developing\_for\_dynamo/10-using-com-(interop)-types-in-dynamo-packages.md)
     * [NodeModel Case Study - Custom UI](11\_developer\_primer/3\_developing\_for\_dynamo/5-nodemodel-case-study-custom-ui.md)
     * [Updating your Packages and Dynamo Libraries for Dynamo 2.x](11\_developer\_primer/3\_developing\_for\_dynamo/6-updating-your-packages-and-dynamo-libraries-for-dynamo-2x.md)
     * [Updating your Packages and Dynamo Libraries for Dynamo 3.x](11\_developer\_primer/3\_developing\_for\_dynamo/updating-your-packages-and-dynamo-libraries-for-dynamo-3x-Net8.md)


### PR DESCRIPTION
### Purpose
Moving [Using COM (interop) types in dynamo packages](https://github.com/DynamoDS/Dynamo/wiki/Using-COM-%28interop%29-types-in-dynamo-packages) from the Dynamo Wiki to the Dynamo Primer.

### Key additions:
A guide covering Using COM (interop) types in dynamo packages.

Proposed location for this guide is under Developer Primer - Developing for Dynamo here:
![image](https://github.com/user-attachments/assets/f2df50f9-84b2-46d1-9d19-f476cd7c7497)

### Declarations
Check these if you believe they are true

- [ ]  The codebase is in a better state after this PR
- [ ]  Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ]  The level of testing this PR includes is appropriate
- [ ]  User facing strings, if any, are extracted into *.resx files
- [ ]  All tests pass using the self-service CI.
- [ ]  Snapshot of UI changes, if any.
- [ ]  Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ]  This PR modifies some build requirements and the readme is updated
- [ ]  This PR contains no files larger than 50 MB

### Release Notes
Adding a guide to the primer covering Using COM (interop) types in dynamo packages.

### Reviewers
@dnenov
@achintyabhat
@QilongTang

Informed
@Amoursol