### PR TITLE
Moving How to update or add a new dependency to dynamo from Wiki to Primer

### DIFF
--- a/11_developer_primer/2_build_dynamo_from_source/2-managing-and-updating-dependancies-in-dynamo.md
+++ b/11_developer_primer/2_build_dynamo_from_source/2-managing-and-updating-dependancies-in-dynamo.md
@@ -1,0 +1,18 @@
+# How To Update or Add a New Dependency to Dynamo
+
+### When does this wiki apply
+While working on a new feature, or simply updating an existing dependency you should evaluate the following before bringing a new dependency into the Dynamo repo.
+
+### Considerations
+1. What is the license of the new or updated dependency - only some open source licenses are approved without speaking with ADSK legal.
+    * After resolving license, make sure the dep and version are recorded in the internal wiki.
+    * If license is `LGPL`, `GPL` or `Apache`, the license file must be copied into the _"Open Source Licenses"_ sub-folder of the Dynamo build.
+    * If license is `LGPL`, the full source code for all third-party components, along with text copies of their appropriate open source licenses, must be uploaded to [www.autodesk.com/lgplsource](https://www.autodesk.com/company/legal-notices-trademarks/open-source-distribution)
+2. If updating, has the license type changed from the previous version?
+3. Is the dependency cross platform? 
+    * Does it have native components (like `CEFSharp` or `ImageMagick`)? This will make it harder to deploy cross platform
+    * Does it have windows only references? If so it should not be as dependency of DynamoCore or other cross platform parts of Dynamo (The model layer).
+4. Is the dependency correctly bundled into the bin folder on build with all of its required dependencies?
+    * If updating, are some files removed as a consequence of updating? Is this version of Dynamo intended for a point release of host products? If so you'll need to keep the old binaries around until a global launch year to support patch installers. See [here](https://github.com/DynamoDS/Dynamo/tree/master/extern/legacy_remove_me).
+5. Does the dependency or its dependency tree conflict with other existing dependencies in Dynamo?
+6. ?? Does the dependency or its dependency tree conflict with existing dependencies in products that integrate Dynamo in process (Revit, Civil etc) - **This is important, as these issues can only be discovered at integration time unless work is done upfront.**

--- a/6_custom_nodes_and_packages/6-2_packages/1-introduction.md
+++ b/6_custom_nodes_and_packages/6-2_packages/1-introduction.md
@@ -91,6 +91,35 @@ If you would like to see where your package files are kept, in the top navigatio
 
 By default, packages are installed in a location similar to this folder path: _C:/Users/\[username]/AppData/Roaming/Dynamo/\[Dynamo Version]_.
 
+### Setting up a Shared Location for Packages in an Office
+
+For users who are asking if it is possible to deploy Dynamo (in any form) with pre-attached packages:
+The approach that will solve this issue and allow for control at a central location for all users with Dynamo installs is to add a custom package path to each installation.
+
+**Adding a network folder where the BIM manager or others could supervise the stocking of the folder with office approved packages**  
+In the UI of an individual application, go to *Dynamo -> Preferences -> Package Settings -> Node and Package file locations*.  In the dialog, press the "Add Path" button and browse to the network location for the shared package resource. 
+ 
+As an automated process, it would involve adding information to the configuration file that is installed with Dynamo:  C:\Users\Username\AppData\Roaming\Dynamo\Dynamo Revit\3.2\DynamoSettings.xml. By default, the configuration for Dynamo for Revit is:
+ 
+`<CustomPackageFolders>`  
+
+`<string>C:\Users\kronz\AppData\Roaming\Dynamo\Dynamo Revit\3.2</string>`  
+
+`</CustomPackageFolders>`
+
+Adding a custom location would look like:  
+
+`<CustomPackageFolders>`  
+
+`<string>C:\Users\kronz\AppData\Roaming\Dynamo\Dynamo Revit\3.2</string>`  
+
+`<string>N:\OfficeFiles\Dynamo\Packages_Limited</string>`  
+
+`</CustomPackageFolders>`
+
+
+The central management for this folder can also be controlled by simply making the folder read only.
+
 ### Loading Packages with Binaries from a Network Location
 
 #### Scenario

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -108,6 +108,7 @@
 * [Developer Primer](11\_developer\_primer/1\_developer\_primer\_intro/README.md)
   * [Build Dynamo from Source](11\_developer\_primer/2\_build\_dynamo\_from\_source/README.md)
     * [Build DynamoRevit from Source](11\_developer\_primer/2\_build\_dynamo\_from\_source/1-build-dynamorevit-from-source.md)
+    * [Managing and Updating Dependancies in Dynamo](11\_developer\_primer/2\_build\_dynamo\_from\_source/2-managing-and-updating-dependancies-in-dynamo.md)]
   * [Developing for Dynamo](11\_developer\_primer/3\_developing\_for\_dynamo/README.md)
     * [Getting Started](11\_developer\_primer/3\_developing\_for\_dynamo/1-getting-started.md)
     * [Zero-Touch Case Study - Grid Node](11\_developer\_primer/3\_developing\_for\_dynamo/2-zero-touch-case-study-grid-node.md)


### PR DESCRIPTION
### Purpose
Moving How To Update or Add a New Dependency to [Dynamo](https://github.com/DynamoDS/Dynamo/wiki/How-To-Update-or-Add-a-New-Dependency-to-Dynamo-%28WIP%29) from the Dynamo Wiki to the Dynamo Primer.

### Key additions:
A guide on How To Update or Add a New Dependency to Dynamo. 

The proposed location for this guide is under Developer Primer - Building Dynamo from Source as a new entry (Open to comments on if this is the best location for it?):
![image](https://github.com/user-attachments/assets/c9a618c7-47bc-45d0-8d8c-17a5c7f4509a)

### Declarations
Check these if you believe they are true
- [ ]  The codebase is in a better state after this PR
- [ ]  Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ]  The level of testing this PR includes is appropriate
- [ ]  User facing strings, if any, are extracted into *.resx files
- [ ]  All tests pass using the self-service CI.
- [ ]  Snapshot of UI changes, if any.
- [ ]  Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ]  This PR modifies some build requirements and the readme is updated
- [ ]  This PR contains no files larger than 50 MB

### Release Notes
A guide on How To Update or Add a New Dependency to Dynamo.

### Reviewers
@dnenov
@achintyabhat
@QilongTang

Informed
@Amoursol