### PR TITLE
Adding Links Within The Primer To Wiki Pages

### DIFF
--- a/11_developer_primer/3_developing_for_dynamo/4-going-further-with-zero-touch.md
+++ b/11_developer_primer/3_developing_for_dynamo/4-going-further-with-zero-touch.md
@@ -167,6 +167,11 @@ Always prioritize clarity, even if that means deviating from these guidelines.
 | Capitalize the first word of a sentence and any proper nouns such as names and traditionally capitalized nouns. <ul><li>Example: Returns the intersection of two *BoundingBoxes*</li></ul>      | Don't capitalize common geometry objects and concepts unless needed for clarity. <ul><li>Example: Scales non-uniformly around the given *Plane*      |
 | Capitalize Boolean. Capitalize True and False when referring to the output of Booleans. <ul><li>Example: Returns *True* if the two values are different</li><li>Example: Converts a string to all uppercase or all lowercase characters based on a *Boolean* parameter      | Don't lowercase Boolean. Don't lowercase True and False when referring to the output of Booleans. <ul><li>Example: Returns *true* if the two values are different</li><li>Example: Converts a string to all uppercase characters or all lowercase characters based on a *boolean* parameter</li></ul>
 
+##### Dynamo Node Warnings and Errors
+
+Node warnings and errors alert the user to an issue with the graph. They notify the user of problems that interfere with normal graph operation by displaying an icon and expanded text bubble above the node. Node errors and warnings can vary in severity: Some graphs can run sufficiently with warnings, while others block expected results. In all cases, node errors and warnings are important tools to keep the user up to date on issues with their graph.
+
+For guidelines to ensure consistency and help save time when writing or updating node warning and error messages please refer to the [Content Pattern: Node Warnings and Errors](https://github.com/DynamoDS/Dynamo/wiki/Content-Pattern:-Node-Warnings-and-Errors) wiki page.
 
 #### Objects <a href="#objects" id="objects"></a>
 

--- a/11_developer_primer/3_developing_for_dynamo/README.md
+++ b/11_developer_primer/3_developing_for_dynamo/README.md
@@ -106,3 +106,8 @@ Dynamo's API documentation currently covers the core functionality: [http://dyna
 Be aware of .dll's included in a package being uploaded to the package manager. If the package author did not create the .dll, they must have the rights to share it.
 
 If a package includes binaries, users must be prompted upon downloading that the package contains binaries.
+
+#### Dynamo UI Performance Considerations
+At the time of writing, Dynamo primarily uses WPF (windows presentation foundation) to render its UI. WPF is a complex and powerful xaml/binding based system. Because Dynamo has a complex UI, it's easy to create UI hangs, memory leaks, or wrap the graph execution and UI updates together in ways that degrade performance.
+
+Please refer to the [Dynamo Performance Considerations Wiki Page](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-UI-Performance) which will help you avoid a few common pitfalls making changes to Dynamo's code.

--- a/5_essential_nodes_and_concepts/5-4_designing-with-lists/1-whats-a-list.md
+++ b/5_essential_nodes_and_concepts/5-4_designing-with-lists/1-whats-a-list.md
@@ -18,7 +18,7 @@ One thing that might seem odd at first is that the first index of a list is alwa
 
 For example, if you were to count the number of fingers we have on our right hand, chances are that you would have counted from 1 to 5. However, if you were to put your fingers in a list, Dynamo would have given them indices from 0 to 4. While this may seem a little strange to programming beginners, the zero-based index is standard practice in most computation systems.
 
-Note that we still have 5 items in the list; it’s just that the list is using a zero-based counting system. And the items being stored in the list don’t just have to be numbers. They can be any data type that Dynamo supports, such as points, curves, surfaces, families, etc.
+Note that we still have 5 items in the list; it's just that the list is using a zero-based counting system. And the items being stored in the list don't just have to be numbers. They can be any data type that Dynamo supports, such as points, curves, surfaces, families, etc.
 
 ![](../images/5-4/1/what'salist-zerobasedindices.jpg)
 
@@ -76,6 +76,36 @@ Finally, the “Cross Product” method makes all possible connections:
 As you can see there are different ways in which we can draw lines between these sets of points. Lacing options are found by right-clicking the center of a node and choosing the "Lacing" menu.
 
 ![](../images/5-4/1/what'salist-rightclicklacingopt.jpg)
+
+### What's Replication?
+
+Imagine you have a bunch of grapes. If you wanted to make grape juice, you wouldn't squeeze each grape individually - you'd put them all through the juicer at once. Replication in Dynamo works in a similar way: instead of applying an operation to one item at a time, Dynamo can apply it to an entire list in one go.
+
+Dynamo nodes automatically recognize when they're working with lists and apply their operations across multiple elements. This means you don't have to manually loop through items - it just happens. But how does Dynamo decide how to process lists when there's more than one?
+
+There are two main ways:
+
+#### Cartesian Replication
+Let's say you're in the kitchen, making fruit juices. You have a list of fruits: `{apple, orange, pear}` and a fixed amount of water for each juice: `1 cup`. You want to make a juice with each fruit, using the same amount of water. In this case, Cartesian Replication comes into play.
+
+In Dynamo, this means you're feeding the list of fruits into the fruit input of the Juice.Maker node, while the water input remains constant at 1 cup. The node then processes each fruit individually, combining it with the fixed amount of water. The result is:
+
+`apple juice with 1 cup of water`
+`orange juice with 1 cup of water`
+`pear juice with 1 cup of water`
+
+Each fruit is paired with the same amount of water.
+
+#### Zip Replication
+Zip Replication works a little differently. If you had two lists, one for fruits: `{apple, orange, pear}` and another for sugar amounts: `{2 tbsp, 3 tbsp, 1 tbsp}`, Zip Replication would combine corresponding items from each list. For example:
+
+`apple juice with 2 tablespoons of sugar`
+`orange juice with 3 tablespoons of sugar`
+`pear juice with 1 tablespoon of sugar`
+
+Each fruit is paired with it's corresponding amount of sugar.
+
+For a deeper dive into how this works, check out the [Replication and Lacing Guides](https://github.com/DynamoDS/Dynamo/wiki/Replication-and-Replication-Guide-Part-1).
 
 ## Exercise
 

--- a/6_custom_nodes_and_packages/6-2_packages/4-publishing.md
+++ b/6_custom_nodes_and_packages/6-2_packages/4-publishing.md
@@ -83,6 +83,11 @@ Note: please do not follow along with this step unless you are actually publishi
 1. When you're ready to publish, in the Packages > Package Manager > Installed Packages window, select the button the right of the package you want to publish and choose Publish.
 2. If you're updating a package that has already been published, choose "Publish Version" and Dynamo will update your package online based on the new files in that package's root directory. Simple as that!
 
+#### Testing the Package Manager Server
+When testing the package manager, don't send your test packages to the production server. Use the staging server. This prevents your packages from polluting real packages and activity. It's easy to configure Dynamo to use the staging server. 
+
+For more information on this, please refer to the [Testing the Package Manager Server Wiki Page](https://github.com/DynamoDS/Dynamo/wiki/Testing-the-Package-Manager-Server).
+
 ### Publish Version...
 
 When you update the files in your published package's root folder, you can also publish a new version of the package by selecting _"Publish Version..."_ in the _My Packages_ tab. This is a seamless way to make necessary updates to your content and share with the community. _Publish Version_ will only work if you're the maintainer of the package.

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -130,6 +130,7 @@
 * [Appendix](a\_appendix/README.md)
   * [Visual Programming and Dynamo](a\_appendix/a-1\_visual-programming-and-dynamo.md)
   * [Resources](a\_appendix/a-2\_resources.md)
+  * [Release Notes](a\_appendix/a-7\_release-notes.md)
   * [Useful Packages](a\_appendix/a-3\_packages.md)
   * [Example Files](a\_appendix/a-4\_example-files.md)
   * [Host Integration Map](a\_appendix/host-integration-map.md)

--- a/a_appendix/a-7_release-notes.md
+++ b/a_appendix/a-7_release-notes.md
@@ -1,0 +1,3 @@
+# Release Notes
+
+For the latest updates, bug fixes, and new features in Dynamo, take a look at the [Release Notes](https://github.com/DynamoDS/Dynamo/wiki/Release-Notes) or the [Release Notes Archive](https://github.com/DynamoDS/Dynamo/wiki/Release-Notes-Archive). They’re a great way to stay up-to-date with the improvements and changes in each release.

--- a/a_appendix/a-7_release-notes.md
+++ b/a_appendix/a-7_release-notes.md
@@ -1,3 +1,3 @@
 # Release Notes
 
-For the latest updates, bug fixes, and new features in Dynamo, take a look at the [Release Notes](https://github.com/DynamoDS/Dynamo/wiki/Release-Notes) or the [Release Notes Archive](https://github.com/DynamoDS/Dynamo/wiki/Release-Notes-Archive). They’re a great way to stay up-to-date with the improvements and changes in each release.
+For the latest updates, bug fixes, and new features in Dynamo, take a look at the [Release Notes](https://github.com/DynamoDS/Dynamo/wiki/Release-Notes) or the [Release Notes Archive](https://github.com/DynamoDS/Dynamo/wiki/Release-Notes-Archive). They're a great way to stay up-to-date with the improvements and changes in each release.


### PR DESCRIPTION
### Purpose
Adding Links Within The Primer To Wiki Pages that are not being moved from the wiki to the primer but still need to be easily accessible for users of the Primer. 

### Key additions:

##### Dynamo UI Performance Considerations
This has been linked in the README file of the Developer Primer -> Developing for Dynamo section:
![image](https://github.com/user-attachments/assets/4336ab62-2c3a-445d-93d8-3d7e813bf5db)

##### Replication Guides
A small section breaking down replication guides and providing links has been added to the Essential Nodes and Concepts -> Designing With Lists -> Whats a list? section:
![image](https://github.com/user-attachments/assets/3a351cd7-7817-4d98-ba59-55bbbf58ed33)

##### Nodes Warning and Errors
A small section and link has been added below the Node Descriptions section under Developing for Dynamo -> Going Further With ZeroTouch here:
![image](https://github.com/user-attachments/assets/f763458c-2eed-46ad-82c4-1585f65ff040)

##### Release Notes and Release Notes Archive
A new section has been added under Appendix, so that this is easy to find for those who want to refer to release notes:
![image](https://github.com/user-attachments/assets/88ae433b-8834-4c82-aec5-373f5cdce2e4)

##### Testing The Package Manager Server
A section has been added within the Custom Nodes & Packages -> Packages -> Publishing a Package -> Publishing a Package Online section:
![image](https://github.com/user-attachments/assets/a20afbf0-ca83-4bf8-80e2-a59412cda6d8)

Some folder management was also done to ensure consistency across the developer primer section. 
### Declarations
Check these if you believe they are true
- [ ]  The codebase is in a better state after this PR
- [ ]  Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ]  The level of testing this PR includes is appropriate
- [ ]  User facing strings, if any, are extracted into *.resx files
- [ ]  All tests pass using the self-service CI.
- [ ]  Snapshot of UI changes, if any.
- [ ]  Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ]  This PR modifies some build requirements and the readme is updated
- [ ]  This PR contains no files larger than 50 MB

### Release Notes
Adding Links Within The Primer To Wiki Pages that are not being moved from the wiki to the primer but still need to be easily accessible for users of the Primer. 

### Reviewers
@dnenov
@achintyabhat
@QilongTang

Informed
@Amoursol