### PR TITLE
Updating the Command Line Interface command list formatting

### DIFF
--- a/11_developer_primer/3_developing_for_dynamo/10-command-line-interface.md
+++ b/11_developer_primer/3_developing_for_dynamo/10-command-line-interface.md
@@ -1,63 +1,41 @@
 # Dynamo Command Line Interface
 
-```plaintext
-      -o, -O, --OpenFilePath        Instruct Dynamo to open a command file and run the commands it contains at 
-                                    this path, this option is only supported when run from DynamoSandbox
-```
+`-o, -O, --OpenFilePath` Instruct Dynamo to open a command file and run the commands it contains at this path. This option is only supported when run from DynamoSandbox.  
 
-<div style="overflow-x: auto; white-space: nowrap;">
+`-c, -C, --CommandFilePath` Instruct Dynamo to open a command file and run the commands it contains at this path. This option is only supported when run from DynamoSandbox.  
 
-```plaintext
-      -c, -C, --CommandFilePath     Instruct Dynamo to open a command file and run the commands it contains at 
-                                    this path, this option is only supported when run from DynamoSandbox                      
-```
+`-v, -V, --Verbose` Instruct Dynamo to output all evaluations it performs to an XML file at the specified path.  
 
-</div> 
+`-g, -G, --Geometry` Instruct Dynamo to output geometry from all evaluations to a JSON file at this path.  
 
-<div style="overflow-x: auto; white-space: nowrap;">
-  <pre>
-    <code>
-      -v, -V, --Verbose             Instruct Dynamo to output all evaluations it performs to an XML file at this path
-    </code>
-  </pre>
-</div>
+`-h, -H, --help` Get some help.  
 
-***                                        
-      -g, -G, --Geometry            Instruct Dynamo to output geometry from all evaluations to a JSON file at this path
-***
-      -h, -H, --help                Get some help
-***
-      -i, -I, --Import              Instruct Dynamo to import an assembly as a node library. This argument should be a 
-                                    file path to a single.dll - if you wish to import multiple dlls - list the dlls 
-                                    separated by a space: -i 'assembly1.dll' 'assembly2.dll'
-***
-      --GeometryPath                Relative or absolute path to a directory containing ASM. When supplied, instead of 
-                                    searching the hard disk for ASM, it will be loaded directly from this path
-***
-      -k, -K, --KeepAlive           Keepalive mode, leave the Dynamo process running until a loaded extension shuts it 
-                                    down
-***
-      --HostName                    Identify Dynamo variation associated with the host
-***
-      -s, -S, --SessionId           Identify Dynamo host analytics session id
-***
-      -p, -P, --ParentId            Identify Dynamo host analytics parent id
-***
-      -x, -X, --ConvertFile         When used in combination with the 'O' flag, opens a .dyn file from the specified 
-                                    path and converts it to .json. The file will have the .json extension and be 
-                                    located in the same directory as the original file
-***
-      -n, -N, --NoConsole           Don't rely on the console window to interact with CLI in Keepalive mode
-***
-      -u, -U  --UserData            Specify user data folder to be used by PathResolver with CLI
-***
-      --CommonData                  Specify common data folder to be used by PathResolver with CLI
-***
-      --DisableAnalytics            Disables analytics in Dynamo for the process lifetime
-***
-      --CERLocation                 Specify the crash error report tool located on the disk
-***
-      --ServiceMode                 Specify the service mode startup
+`-i, -I, --Import` Instruct Dynamo to import an assembly as a node library. This argument should be a file path to a single `.dll`. If you wish to import multiple `.dlls`, list them separated by a space: `-i 'assembly1.dll' 'assembly2.dll'`.  
+
+`--GeometryPath` Relative or absolute path to a directory containing ASM. When supplied, instead of searching the hard disk for ASM, it will be loaded directly from this path.  
+
+`-k, -K, --KeepAlive` Keepalive mode, leave the Dynamo process running until a loaded extension shuts it down.  
+
+`--HostName` Identify Dynamo variation associated with the host.  
+
+`-s, -S, --SessionId` Identify Dynamo host analytics session ID.  
+
+`-p, -P, --ParentId` Identify Dynamo host analytics parent ID.  
+
+`-x, -X, --ConvertFile` When used in combination with the `-O` flag, opens a `.dyn` file from the specified path and converts it to `.json`. The file will have the `.json` extension and be located in the same directory as the original file.  
+
+`-n, -N, --NoConsole` Don't rely on the console window to interact with CLI in Keepalive mode.  
+
+`-u, -U, --UserData` Specify user data folder to be used by PathResolver with CLI.  
+
+`--CommonData` Specify common data folder to be used by PathResolver with CLI.  
+
+`--DisableAnalytics` Disables analytics in Dynamo for the process lifetime.  
+
+`--CERLocation` Specify the crash error report tool located on the disk.  
+
+`--ServiceMode` Specify the service mode startup.  
+
 
 
 #### Why 
@@ -80,7 +58,7 @@ In preliminary testing, the CLI utility supports localized versions of Windows a
 
 The CLI can be accessed through the DynamoCLI.exe application. This application lets a user or another application interact with the Dynamo evaluation model by invoking DynamoCLI.exe with a command string. This might look something like this:
  
-    C:\Program Files\Dynamo\Dynamo Core\[Dynamo Version]\DynamoCLI.exe -o "C:\someReallyCoolDynamoFile.Dyn"
+ `C:\Program Files\Dynamo\Dynamo Core\[Dynamo Version]\DynamoCLI.exe -o "C:\someReallyCoolDynamoFile.Dyn"`
  
 This command will tell Dynamo to open the specified file at *"C:\someReallyCoolDynamoFile.Dyn"*, without drawing any UI, and then run it. Dynamo will then exit when the graph has completed running. 
 
@@ -98,13 +76,13 @@ This command will tell Dynamo to open the specified file at *"C:\someReallyCoolD
 #### How
 
 `-o` you can open dynamo pointing to a .dyn,  in a headless mode that will run the graph.
-```
-    C:\Program Files\Dynamo\Dynamo Core\[Dynamo Version]\DynamoCLI.exe -o "C:\someReallyCoolDynamoFile.Dyn"
-```
+
+`C:\Program Files\Dynamo\Dynamo Core\[Dynamo Version]\DynamoCLI.exe -o "C:\someReallyCoolDynamoFile.Dyn"`
+
 `-v` can be used when Dynamo is running in a headless mode (when we have used `-o` to open a file), this flag will iterate all nodes in the graph and dump their output values to a simple XML file. Because the `--ServiceMode` flag can force Dynamo to run multiple graph evaluations, the output file will hold values for each evaluation that occurs.
-```
-    C:\Program Files\Dynamo\Dynamo Core\[Dynamo Version]\DynamoCLI.exe -o "C:\someReallyCoolDynamoFile.Dyn" -p "C:\aFileWithPresetsInIt.dyn" --ServiceMode "all" -v "C:\output.xml"
-```
+
+`C:\Program Files\Dynamo\Dynamo Core\[Dynamo Version]\DynamoCLI.exe -o "C:\someReallyCoolDynamoFile.Dyn" -p "C:\aFileWithPresetsInIt.dyn" --ServiceMode "all" -v "C:\output.xml"`
+
         
 The XML output file would have the form:
 ``` XML
@@ -134,52 +112,49 @@ The XML output file would have the form:
     </evaluations>
 ```
 `-g` can be used when Dynamo is running in a headless mode (when we have used `-o` to open a file), this flag will generate the graph and then dump the resulting geometry into a JSON file. 
-```
-    C:\Program Files\Dynamo\Dynamo Core\[Dynamo Version]\DynamoWPFCLI.exe -o "C:\someReallyCoolDynamoFile.Dyn" -g "C:\geometry.json"
-```  
+
+`C:\Program Files\Dynamo\Dynamo Core\[Dynamo Version]\DynamoWPFCLI.exe -o "C:\someReallyCoolDynamoFile.Dyn" -g "C:\geometry.json"`
+  
 The JSON geometry file would have the form:
-```
- TBD - Work in progress
-```
+
+ TBD - Work in progress`
+
 `-h` use this to get a list of the possible options
-```
-    C:\Program Files\Dynamo\Dynamo Core\[Dynamo Version]\DynamoCLI.exe -h
-```
+
+`C:\Program Files\Dynamo\Dynamo Core\[Dynamo Version]\DynamoCLI.exe -h`
+
 the -i flag can be used multiple times to import multiple assemblies which the graph you are trying to open requires to run.
-```
-    C:\Program Files\Dynamo\Dynamo Core\[Dynamo Version]\DynamoCLI.exe -o "C:\someReallyCoolDynamoFile.Dyn" -i"a.dll" -i"aSecond.dll"
-```
+
+`C:\Program Files\Dynamo\Dynamo Core\[Dynamo Version]\DynamoCLI.exe -o "C:\someReallyCoolDynamoFile.Dyn" -i"a.dll" -i"aSecond.dll"`
 
 the -l flag can be used to run Dynamo under a different locale setting. But usually, locale setting does not affect graph results
-```
-    C:\Program Files\Dynamo\Dynamo Core\[Dynamo Version]\DynamoCLI.exe -o "C:\someReallyCoolDynamoFile.Dyn" -l "de-DE"
-```
+
+`C:\Program Files\Dynamo\Dynamo Core\[Dynamo Version]\DynamoCLI.exe -o "C:\someReallyCoolDynamoFile.Dyn" -l "de-DE"`
 
 the --GeometryPath flag can be used to point DynamoSandbox or CLI to a specific set of ASM binaries - use it like
-```
-    C:\Program Files\Dynamo\Dynamo Core\[Dynamo Version]\DynamoSandbox.exe --GeometryPath "\pathToGeometryBinaries\"
-```
+
+`C:\Program Files\Dynamo\Dynamo Core\[Dynamo Version]\DynamoSandbox.exe --GeometryPath "\pathToGeometryBinaries\"`
 
 or
-```
-    C:\Program Files\Dynamo\Dynamo Core\[Dynamo Version]\DynamoSandbox.exe --GeometryPath "\pathToGeometryBinaries\"
-```
+
+`C:\Program Files\Dynamo\Dynamo Core\[Dynamo Version]\DynamoSandbox.exe --GeometryPath "\pathToGeometryBinaries\"`
+
 the -k flag can be used to leave the Dynamo process running until a loaded extension shuts it down.
-```
-    C:\Program Files\Dynamo\Dynamo Core\[Dynamo Version]\DynamoCLI.exe -k
-```
+
+`C:\Program Files\Dynamo\Dynamo Core\[Dynamo Version]\DynamoCLI.exe -k`
+
 the --HostName flag can be used to identify Dynamo variation associated with the host.
-```
-    C:\Program Files\Dynamo\Dynamo Core\[Dynamo Version]\DynamoCLI.exe --HostName "DynamoFormIt"
-```
+
+`C:\Program Files\Dynamo\Dynamo Core\[Dynamo Version]\DynamoCLI.exe --HostName "DynamoFormIt"`
+
 or
-```
-    C:\Program Files\Dynamo\Dynamo Core\[Dynamo Version]\DynamoSandbox.exe --HostName "DynamoFormIt"
-```
+
+`C:\Program Files\Dynamo\Dynamo Core\[Dynamo Version]\DynamoSandbox.exe --HostName "DynamoFormIt"`
+
 the -s flag can be used to identify Dynamo host analytics session id
-```
-    C:\Program Files\Dynamo\Dynamo Core\[Dynamo Version]\DynamoCLI.exe -s [HostSessionId]
-```
+
+`C:\Program Files\Dynamo\Dynamo Core\[Dynamo Version]\DynamoCLI.exe -s [HostSessionId]`
+
 the -p flag can be used to identify Dynamo host analytics parent id
-```
-    C:\Program Files\Dynamo\Dynamo Core\[Dynamo Version]\DynamoCLI.exe -p "RVT&2022&MUI64&22.0.2.392"
+
+`C:\Program Files\Dynamo\Dynamo Core\[Dynamo Version]\DynamoCLI.exe -p "RVT&2022&MUI64&22.0.2.392"`


### PR DESCRIPTION
### Purpose
Updating the Command Line Interface command list to remove it from Code Blocks and format it in the same manner as the "Dynamo Keyboard Shortcuts" page of the primer.

Old formatting meant you couldnt see all of the text for each item:
![image](https://github.com/user-attachments/assets/5855be85-8140-4ee8-8154-3a39f4f7d4d4)


New formatting displayed in VS Markdown viewer:
![image](https://github.com/user-attachments/assets/405f041f-bc44-4d0a-8151-56ba577732a3)


### Key additions:
Updating the Command Line Interface command list to remove it from Code Blocks and format it in the same manner as the "Dynamo Keyboard Shortcuts" page of the primer.

### Declarations
Check these if you believe they are true
- [ ]  The codebase is in a better state after this PR
- [ ]  Is documented according to the [standards](https://github.com/DynamoDS/Dynamo/wiki/Coding-Standards)
- [ ]  The level of testing this PR includes is appropriate
- [ ]  User facing strings, if any, are extracted into *.resx files
- [ ]  All tests pass using the self-service CI.
- [ ]  Snapshot of UI changes, if any.
- [ ]  Changes to the API follow [Semantic Versioning](https://github.com/DynamoDS/Dynamo/wiki/Dynamo-Versions) and are documented in the [API Changes](https://github.com/DynamoDS/Dynamo/wiki/API-Changes) document.
- [ ]  This PR modifies some build requirements and the readme is updated
- [ ]  This PR contains no files larger than 50 MB

### Release Notes
Updating the Command Line Interface command list to remove it from Code Blocks and format it in the same manner as the "Dynamo Keyboard Shortcuts" page of the primer.

### Reviewers
@dnenov
@achintyabhat
@QilongTang

Informed
@Amoursol