### PR TITLE
CBC Phase 1 - Stretch Goal

### DIFF
--- a/11_developer_primer/2_build_dynamo_from_source/1-build-dynamorevit-from-source.md
+++ b/11_developer_primer/2_build_dynamo_from_source/1-build-dynamorevit-from-source.md
@@ -208,7 +208,7 @@ Since this is not an open source library, we cannot make changes there - now tha
 > 3. In the Call Stack, we can see that the exception is coming from non-user code
 > 4. A pop-up window giving us information about the exception
 
-This process can be applied to any source files we are working with. If we are developing a library of Zero-Touch nodes for Dynamo Studio, we can open the library's source and attach a Dynamo process to debug the node library. Even if everything is functioning perfectly, debugging is a great way to explore code and find out how things are working.
+This process can be applied to any source files we are working with. If we are developing a library of Zero-Touch nodes for Dynamo, we can open the library's source and attach a Dynamo process to debug the node library. Even if everything is functioning perfectly, debugging is a great way to explore code and find out how things are working.
 
 ### Pull latest build <a href="#pull-latest-build" id="pull-latest-build"></a>
 

--- a/11_developer_primer/3_developing_for_dynamo/13-dynamo-integration.md
+++ b/11_developer_primer/3_developing_for_dynamo/13-dynamo-integration.md
@@ -8,8 +8,8 @@ Contents:
 
 * [This Intro](13-dynamo-integration.md#dynamo-integration) High level overview of what this guide includes, and what Dynamo is all about.
 * [Dynamo Custom Entry Point](13-dynamo-integration.md#dynamo-custom-entry-point) How to create a DynamoModel and where to start.
-* [Element Binding and Trace](13-dynamo-integration.md#-element-binding-and-trace) Using Dynamo's trace mechanism to bind nodes in the graph to their results in your host.
-* [Dynamo Revit Selection Nodes](13-dynamo-integration.md#-dynamo-revit-selection-nodes) How to implement nodes that allow users to select objects or data from your host and pass them as inputs to the Dynamo graph.
+* [Element Binding and Trace](13-dynamo-integration.md#element-binding-and-trace) Using Dynamo's trace mechanism to bind nodes in the graph to their results in your host.
+* [Dynamo Revit Selection Nodes](13-dynamo-integration.md#dynamo-revit-selection-nodes-what-are-they) How to implement nodes that allow users to select objects or data from your host and pass them as inputs to the Dynamo graph.
 * [Dynamo Built-In Packages Overview](13-dynamo-integration.md#dynamo-built-in-packages-overview) What is the Dynamo Standard Library, and how to use the underlying mechanism to ship packages with your integration.
 
 **Some diction:**
@@ -637,9 +637,10 @@ Selection nodes are implemented by inheriting from the generic `SelectionBase` t
 #### DynamoCore base classes:
 
 * [https://github.com/DynamoDS/Dynamo/blob/ec10f936824152e7dd7d6d019efdcda0d78a5264/src/Libraries/CoreNodeModels/Selection.cs](https://github.com/DynamoDS/Dynamo/blob/ec10f936824152e7dd7d6d019efdcda0d78a5264/src/Libraries/CoreNodeModels/Selection.cs)
-* [NodeModel Case Study - Custom UI](11_developer_primer/3_developing_for_dynamo/5-nodemodel-case-study-custom-ui.md)
-* [Updating your Packages and Dynamo Libraries for Dynamo 2.x](11_developer_primer/3_developing_for_dynamo/6-updating-your-packages-and-dynamo-libraries-for-dynamo-2x.md)
-* [Updating your Packages and Dynamo Libraries for Dynamo 3.x](11_developer_primer/3_developing_for_dynamo/updating-your-packages-and-dynamo-libraries-for-dynamo-3x-Net8.md)
+* [NodeModel Case Study - Custom UI](5-nodemodel-case-study-custom-ui.md)
+* [Updating your Packages and Dynamo Libraries for Dynamo 2.x](6-0-updating-your-packages-and-dynamo-libraries-for-dynamo-2x.md)
+* [Updating your Packages and Dynamo Libraries for Dynamo 3.x](6-1-updating-your-packages-and-dynamo-libraries-for-dynamo-3x-Net8.md)
+* [Updating your Packages and Dynamo Libraries for Dynamo 4.x](6-2-updating-your-packages-and-dynamo-libraries-for-dynamo-4x.md)
 
 #### DynamoRevit:
 

--- a/11_developer_primer/3_developing_for_dynamo/2-zero-touch-case-study-grid-node.md
+++ b/11_developer_primer/3_developing_for_dynamo/2-zero-touch-case-study-grid-node.md
@@ -22,7 +22,7 @@ Since we will be creating geometry, we need to reference the appropriate NuGet p
 ![ZeroTouchLibrary package](../../.gitbook/assets/vs-nugetpackage.jpg)
 
 > 1. Browse for the ZeroTouchLibrary package
-> 2. We will be using this node in the current build of Dynamo Studio, which is 1.3. Select the package version that matches this.
+> 2. We will be using this node in the current build of Dynamo. Select the package version that matches your Dynamo version.
 > 3. Notice that we have also renamed the class file to `Grids.cs`
 
 Next, we need to establish a namespace and class in which the RectangularGrid method will live. The node will be named in Dynamo according to the method and class names. We don't have to copy this into Visual Studio yet.


### PR DESCRIPTION
**Purpose:**

1. To remove the word "Dynamo Studio" from Primer documentation
2. To fix the invalid links(marked in rectangles in the below images) in Developer Primer --> Dynamo Integration section
<img width="625" height="187" alt="image" src="https://github.com/user-attachments/assets/98e72e60-75fe-4cc5-9f2f-491567db416f" />
<img width="689" height="321" alt="image" src="https://github.com/user-attachments/assets/fe357e7f-b05c-40fc-95f7-84547f946e7b" />

**Changes:**
1. Replaced the word "Dynamo Studio" in 2 places and modified the content to match the context.
2. Fixed the following links in "Dynamo Integration" section
        - Element Binding and Trace, 
        - Dynamo Revit Selection Nodes, 
        - NodeModel Case Study - Custom UI, 
        - Updating your packages and Dynamo Libraries for Dynamo 2.x, 
        - Updating your packages and Dynamo Libraries for Dynamo 3.x
3. Added a new link reference to Updating your packages and Dynamo Libraries for Dynamo 4.x in "Dynamo Integration" section

